### PR TITLE
Pass context to kubernetes clean command

### DIFF
--- a/src/kubernetes/clean.rs
+++ b/src/kubernetes/clean.rs
@@ -14,6 +14,7 @@ use kube::{
     api::{Api, ListParams},
     Client,
 };
+use kube::{Config, ResourceExt};
 use log::{debug, info};
 use regex::Regex;
 use tokio::join;
@@ -108,21 +109,20 @@ async fn clean_config_maps(
         get_resources::<CronJob>(&client, namespace),
         get_ownerless_resources::<Job>(&client, namespace),
     );
+
+    let mut used_config_maps = get_config_map_references(free_pods?);
+    used_config_maps.extend(get_config_map_references(deployments?).into_iter());
+    used_config_maps.extend(get_config_map_references(replicasets?).into_iter());
+    used_config_maps.extend(get_config_map_references(statefulsets?).into_iter());
+    used_config_maps.extend(get_config_map_references(daemonsets?).into_iter());
+    used_config_maps.extend(get_config_map_references(cronjobs?).into_iter());
+    used_config_maps.extend(get_config_map_references(free_jobs?).into_iter());
     debug!("Done fetching resources from the Kubernetes API server.");
 
-    let mut used_config_maps = get_config_map_references(free_pods);
-    used_config_maps.extend(get_config_map_references(deployments).into_iter());
-    used_config_maps.extend(get_config_map_references(replicasets).into_iter());
-    used_config_maps.extend(get_config_map_references(statefulsets).into_iter());
-    used_config_maps.extend(get_config_map_references(daemonsets).into_iter());
-    used_config_maps.extend(get_config_map_references(cronjobs).into_iter());
-    used_config_maps.extend(get_config_map_references(free_jobs).into_iter());
-
-    let config_maps: HashSet<String> = config_maps
+    let config_maps: HashSet<String> = config_maps?
         .into_iter()
         .map(|config_map| config_map.name_any())
         .collect();
-
     let unused_config_maps: HashSet<String> = config_maps
         .difference(&used_config_maps)
         .filter(|config_map| {
@@ -138,7 +138,6 @@ async fn clean_config_maps(
                     .unwrap()
                     .find(config_map.as_str())
                     .is_some();
-
                 if inverse_filter {
                     if is_matching {
                         info!("Will not delete config map {config_map} because it's filtered-out.");
@@ -158,18 +157,15 @@ async fn clean_config_maps(
         })
         .cloned()
         .collect();
-
     info!(
         "There are {} config maps, {} are used, {} will be removed.",
         config_maps.len(),
         used_config_maps.len(),
         unused_config_maps.len()
     );
-
     unused_config_maps
         .iter()
         .for_each(|config_map| println!("{config_map}"));
-
     if dry_run {
         info!("Not deleting anything")
     } else {
@@ -193,28 +189,23 @@ async fn get_resources<
 >(
     client: &Client,
     namespace: Option<&String>,
-) -> Vec<K> {
+) -> Result<Vec<K>, Box<dyn std::error::Error>> {
     let client = Cow::Borrowed(client);
     let resources: Api<K> = match namespace {
         Some(ns) => Api::namespaced(client.into_owned(), ns),
         None => Api::default_namespaced(client.into_owned()),
     };
-
-    match resources.list(&ListParams::default()).await {
-        Ok(list) => {
-            if !list.items.is_empty() {
-                debug!(
-                    "Got {} {}{} from the namespace {}",
-                    list.items.len(),
-                    K::KIND,
-                    if list.items.len() > 1 { "s" } else { "" },
-                    list.items[0].metadata().namespace.as_ref().unwrap()
-                );
-            }
-            list.items
-        }
-        Err(_) => Vec::new(),
+    let objects = resources.list(&ListParams::default()).await?;
+    if !objects.items.is_empty() {
+        debug!(
+            "Got {} {}{} from the namespace {}",
+            objects.items.len(),
+            K::KIND,
+            if objects.items.len() > 1 { "s" } else { "" },
+            objects.items[0].metadata().namespace.as_ref().unwrap()
+        );
     }
+    Ok(objects.items)
 }
 
 async fn get_ownerless_resources<
@@ -226,9 +217,9 @@ async fn get_ownerless_resources<
 >(
     client: &Client,
     namespace: Option<&String>,
-) -> Vec<K> {
-    get_resources::<K>(client, namespace)
-        .await
+) -> Result<Vec<K>, Box<dyn std::error::Error>> {
+    let result: Vec<K> = get_resources::<K>(client, namespace)
+        .await?
         .into_iter()
         .filter(|resource| resource.metadata().owner_references.is_none())
         .inspect(|resource| {
@@ -238,7 +229,8 @@ async fn get_ownerless_resources<
                 resource.metadata().name.as_ref().unwrap(),
             )
         })
-        .collect()
+        .collect();
+    Ok(result)
 }
 
 async fn delete_resources<
@@ -251,19 +243,18 @@ async fn delete_resources<
     client: &Client,
     namespace: Option<&String>,
     targets: Vec<String>,
-) {
+) -> Result<(), Box<dyn std::error::Error>> {
     let client = Cow::Borrowed(client);
     let resources: Api<K> = match namespace {
         Some(ns) => Api::namespaced(client.into_owned(), ns),
         None => Api::default_namespaced(client.into_owned()),
     };
-
-    // 9.km
     for ref target in targets {
-        let _ = resources
+        resources
             .delete(target.as_str(), &DeleteParams::default())
-            .await;
+            .await?;
     }
+    Ok(())
 }
 
 trait HasPodSpec {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,14 +20,14 @@ enum Groups {
 fn main() {
     let args = Args::parse();
 
-    match args.group {
+    let _ = match args.group {
         Groups::Kubernetes { command } => match command {
             kubernetes::Commands::Clean(args) => {
                 configure_logger(args.verbosity);
-                let _ = kubernetes::clean::handle(args);
+                kubernetes::clean::handle(args)
             }
         },
-    }
+    };
 }
 
 fn configure_logger(verbosity: u8) {


### PR DESCRIPTION
Following kubectl commands and plugins, users should be able to pass `--context`.
I also improved error handling, so messages won't be misleading.